### PR TITLE
fix wrong warning condition

### DIFF
--- a/models/vgg.py
+++ b/models/vgg.py
@@ -124,7 +124,7 @@ class VGG(nn.Module):
         assert all([t in self.names for t in targets]),\
             'Specified name does not exist.'
 
-        if torch.all(x < 0.) and torch.all(x > 1.):
+        if torch.any(x < 0.) and torch.any(x > 1.):
             warnings.warn('input tensor is not normalize to [0, 1].')
 
         x = self.z_score(x)


### PR DESCRIPTION
The input is not normalized if any of the element in the tensor is outside [0, 1].

    import torch
  
    x = torch.tensor([-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
    
    if torch.all(x < 0.) and torch.all(x > 1.) :
        print('yes')
    else:
        print("But they are not normalized to [0,1]!")
    
    if torch.all(x >= 0.) and torch.any(x <= 1.) :
        print("this is correct way to check if they are normalized to [0,1]")


    >>>But they are not normalized to [0,1]!
    >>>this is correct way to check if they are normalized to [0,1]